### PR TITLE
EVG-14486: use archlinux-new distros in CI tests

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -152,7 +152,7 @@ buildvariants:
       GO_BIN_PATH: /opt/golang/go1.13/bin/go
       GOROOT: /opt/golang/go1.13
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks: [ "testGroup" ]
 
   - name: lint
@@ -162,7 +162,7 @@ buildvariants:
       GOROOT: /opt/golang/go1.13
       DISABLE_COVERAGE: true
     run_on:
-      - archlinux-test
+      - archlinux-new-small
     tasks: [ "lintGroup" ]
 
   - name: ubuntu1604


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-14486