### PR TITLE
EVG-14482, EVG-14502: upgrade go version and linter

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -35,15 +35,15 @@ functions:
     params:
       working_dir: gopath/src/github.com/evergreen-ci/barque/
       binary: make
-      args: ["${make_args|}", "${target}"]
-      add_expansions_to_env: true
+      args: ["${target}"]
+      include_expansions_in_env: ["DISABLE_COVERAGE", "GO_BIN_PATH", "GOROOT"]
       env:
         GOPATH: ${workdir}/gopath
   set-up-mongodb:
     - command: subprocess.exec
       type: setup
       params:
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         working_dir: gopath/src/github.com/evergreen-ci/barque/
         command: make get-mongodb
     - command: subprocess.exec
@@ -51,18 +51,18 @@ functions:
       params:
         background: true
         working_dir: gopath/src/github.com/evergreen-ci/barque/
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         command: make start-mongod
     - command: subprocess.exec
       type: setup
       params:
         working_dir: gopath/src/github.com/evergreen-ci/barque/
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         command: make check-mongod
     - command: subprocess.exec
       type: setup
       params:
-        add_expansions_to_env: true
+        include_expansions_in_env: ["MONGODB_URL"]
         working_dir: gopath/src/github.com/evergreen-ci/barque/
         command: make init-rs
 
@@ -148,9 +148,9 @@ buildvariants:
     display_name: Race Detector (Arch Linux)
     expansions:
       RACE_DETECTOR: true
-      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.0.13.tgz
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.13.tgz
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
     tasks: [ "testGroup" ]
@@ -158,30 +158,30 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       DISABLE_COVERAGE: true
     run_on:
       - archlinux-new-small
     tasks: [ "lintGroup" ]
 
-  - name: ubuntu1604
-    display_name: Ubuntu 16.04
+  - name: ubuntu
+    display_name: Ubuntu 18.04
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.9/bin/go
-      GOROOT: /opt/golang/go1.9
-      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1604-4.0.13.tgz
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
+      MONGODB_URL: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.13.tgz
     run_on:
-      - ubuntu1604-test
+      - ubuntu1804-small
     tasks: [ "dist", "testGroup" ]
 
   - name: macos
     display_name: macOS
     expansions:
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: /opt/golang/go1.13/bin/go
-      GOROOT: /opt/golang/go1.13
+      GO_BIN_PATH: /opt/golang/go1.16/bin/go
+      GOROOT: /opt/golang/go1.16
       MONGODB_URL: https://fastdl.mongodb.org/osx/mongodb-osx-ssl-x86_64-4.0.13.tgz
     run_on:
       - macos-1014
@@ -197,6 +197,6 @@ buildvariants:
     expansions:
       MONGODB_URL: https://fastdl.mongodb.org/win32/mongodb-win32-x86_64-2008plus-ssl-4.0.13.zip
       DISABLE_COVERAGE: true
-      GO_BIN_PATH: C:/golang/go1.13/bin/go
-      GOROOT: C:/golang/go1.13
+      GO_BIN_PATH: /cygdrive/c/golang/go1.16/bin/go
+      GOROOT: C:/golang/go1.16
     tasks: [ "testGroup" ]

--- a/makefile
+++ b/makefile
@@ -24,6 +24,7 @@ endif
 export GOPATH := $(gopath)
 export GOCACHE := $(gocache)
 export GOROOT := $(goroot)
+export GO111MODULE := off
 # end environment setup
 
 
@@ -34,7 +35,7 @@ $(shell mkdir -p $(buildDir))
 # start lint setup targets
 lintDeps := $(buildDir)/golangci-lint $(buildDir)/run-linter
 $(buildDir)/golangci-lint:
-	@curl  --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.30.0 >/dev/null 2>&1
+	@curl  --retry 10 --retry-max-time 60 -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/76a82c6ed19784036bbf2d4c84d0228ca12381a4/install.sh | sh -s -- -b $(buildDir) v1.40.0 >/dev/null 2>&1
 $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 	@mkdir -p $(buildDir)
 	$(gobin) build -o $@ $<
@@ -58,7 +59,7 @@ $(buildDir)/$(name):$(srcFiles)
 	$(gobin) build -ldflags "-X github.com/evergreen-ci/barque.BuildRevision=`git rev-parse HEAD`" -o $@ cmd/$(name)/$(name).go
 $(buildDir)/make-tarball:cmd/make-tarball/make-tarball.go
 	@mkdir -p $(buildDir)
-	GOOS=$(go env GOOS) $(gobin) build -o $@ $<
+	GOOS="" GOARCH="" $(gobin) build -o $@ $<
 # end dependency installation tools
 
 


### PR DESCRIPTION
Jira:
https://jira.mongodb.org/browse/EVG-14482
https://jira.mongodb.org/browse/EVG-14502

* Upgrade go to 1.16.
* Upgrade golangci-lint to 1.40.
* Upgrade Ubuntu to 18.04.