### PR TITLE
EVG-15478: disable cgo

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,6 +23,12 @@ export GOROOT := $(shell cygpath -m $(GOROOT))
 endif
 
 export GO111MODULE := off
+ifneq (,$(RACE_DETECTOR))
+# cgo is required for using the race detector.
+export CGO_ENABLED=1
+else
+export CGO_ENABLED=0
+endif
 # end environment setup
 
 # Ensure the build directory exists, since most targets require it
@@ -35,7 +41,7 @@ $(shell mkdir -p $(buildDir))
 $(name): $(buildDir)/$(name)
 	@[ -e $@ ] || ln -s $<
 $(buildDir)/$(name): $(srcFiles)
-	$(gobin) build -ldflags "-X github.com/evergreen-ci/barque.BuildRevision=`git rev-parse HEAD`" -o $@ cmd/$(name)/$(name).go
+	$(gobin) build -ldflags "-X github.com/evergreen-ci/barque.BuildRevision=`git rev-parse HEAD`" -trimpath -o $@ cmd/$(name)/$(name).go
 $(buildDir)/make-tarball: cmd/make-tarball/make-tarball.go
 	GOOS="" GOARCH="" $(gobin) build -o $@ $<
 distContents := $(buildDir)/$(name)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15478

Evergreen is compiled without cgo so it's preferable to test/compile without cgo in all repos to avoid discrepancies in behavior.

* Disable cgo.
* Compile binary with `-trimpath`.