### PR TITLE
rpm: remove .repodata instead of .olddata

### DIFF
--- a/repobuilder/rpm.go
+++ b/repobuilder/rpm.go
@@ -51,8 +51,8 @@ func (j *rpmRepoBuilder) rebuildRepo(workingDir string) error {
 	} else {
 		// remove olddata before running createrepo or else the command
 		// will fail if it exists.
-		if err = os.RemoveAll(filepath.Join(workingDir, ".olddata")); err != nil {
-			return errors.Wrap(err, "problem removing .olddata dir")
+		if err = os.RemoveAll(filepath.Join(workingDir, ".repodata")); err != nil {
+			return errors.Wrap(err, "problem removing temp .repodata dir")
 		}
 
 		grip.Notice(message.Fields{


### PR DESCRIPTION
The old createrepo Python tool stored temporary files in `$(pwd)/.olddata` and Barque was set up to clean out that directory on each build. Createrepo_c, however, stores temporary files at `$(pwd)/.repodata`. On subsequent publishes to the same repo, this will cause errors if we're using createrepo_c because for some strange reason createrepo(_c) does not remove the directory if it already exists. Since all of our app servers are now using createrepo_c, we need to adjust this code to remove the correct temporary directory.

References:
[Old createrepo default](https://github.com/rpm-software-management/createrepo/blob/73afabbd0d3357bc24a82126acc3a4bc96bcd7c7/createrepo/__init__.py#L101)
[New createrepo default](https://github.com/rpm-software-management/createrepo_c/blob/ace4c87a392b8c25fd7127da49516dba52d397c9/src/mergerepo_c.c#L229)